### PR TITLE
Updated return type of getResolution

### DIFF
--- a/src/main/java/com/bitalino/util/SensorDataConverter.java
+++ b/src/main/java/com/bitalino/util/SensorDataConverter.java
@@ -130,8 +130,8 @@ public class SensorDataConverter {
    * @param port
    * @return the resolution (maximum value) for a certain port.
    */
-  private static final int getResolution(final int port) {
-    return port < 4 ? 1023 : 63;
+  private static final double getResolution(final int port) {
+    return (double) port < 4 ? 1023 : 63;
   }
 
 }


### PR DESCRIPTION
`getResolution(int port)`returned an int, causing Integer division in multiple of the scaling-methods. Updated return value to double to avoid Integer division.
