### PR TITLE
Added tests

### DIFF
--- a/src/test/java/com/bitalino/util/SensorDataConverterTest.java
+++ b/src/test/java/com/bitalino/util/SensorDataConverterTest.java
@@ -38,20 +38,44 @@ public class SensorDataConverterTest {
 
     @Test
     public void test_ecg_conversion() {
-        assertEquals(SensorDataConverter.scaleECG(0, 0), 0.0);
-        assertEquals(SensorDataConverter.scaleECG(0, 1023), 3.0);
+        assertEquals(SensorDataConverter.scaleECG(0, 0), -1.5);
+        assertEquals(SensorDataConverter.scaleECG(0, 1023), 1.5);
     }
 
     @Test
     public void test_eda_conversion() {
-        assertEquals(SensorDataConverter.scaleEDA(0, 0), 0.0);
-        assertEquals(SensorDataConverter.scaleEDA(0, 1023), 1.055);
+        assertEquals(SensorDataConverter.scaleEDA(0, 0), 1.0);
+        assertEquals(SensorDataConverter.scaleEDA(0, 1023), Double.POSITIVE_INFINITY);
     }
 
     @Test
     public void test_luminosity_conversion() {
         assertEquals(SensorDataConverter.scaleLuminosity(0, 0), 0.0);
         assertEquals(SensorDataConverter.scaleLuminosity(0, 1023), 100.0);
+    }
+    
+    @Test
+    public void test_tmp_celsius_conversion() {
+        assertEquals(SensorDataConverter.scaleTMP(0, 0, true), -50.0);
+        assertEquals(SensorDataConverter.scaleTMP(0, 1023, true), 280.0);
+    }
+        
+    @Test
+    public void test_tmp_fahrenheit_conversion() {
+        assertEquals(SensorDataConverter.scaleTMP(0, 0, false), -58.0);
+        assertEquals(SensorDataConverter.scaleTMP(0, 1023, false), 536.0);
+    }
+
+    @Test
+    public void test_pzt_conversion() {
+        assertEquals(SensorDataConverter.scalePZT(0, 0), -50.0);
+        assertEquals(SensorDataConverter.scalePZT(0, 1023), 50.0);
+    }
+    
+    @Test
+    public void test_EEG_conversion() {
+        assertEquals(SensorDataConverter.scaleEEG(0, 0), -41.25);
+        assertEquals(SensorDataConverter.scaleEEG(0, 1023), 41.25);
     }
 
 }


### PR DESCRIPTION
Added tests for PZT, EEG and TMP; both celsius and fahrenheit. 
Updated the  assert-value of the ECG and EDA tests.

Btw, the range given by the accelerometer transfer function from the bitalino webpage is not -3G to 3G as specified in the documentation. It is -5.11 to 17.62 using ACC_MIN = 185 and ACC_MAX = 275. 
